### PR TITLE
Move RegisterForm components to forms directory

### DIFF
--- a/printlib-frontend/src/App.tsx
+++ b/printlib-frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import LoginForm from './components/forms/LoginForm';
-import RegisterForm from './components/RegisterForm';
+import RegisterForm from './components/forms/RegisterForm';
 import { login, register } from './api/auth';
 import './styles/theme.scss';
 

--- a/printlib-frontend/src/components/forms/RegisterForm.module.scss
+++ b/printlib-frontend/src/components/forms/RegisterForm.module.scss
@@ -1,5 +1,5 @@
-@import '../styles/variables';
-@import './forms/LoginForm.module.scss';
+@import '../../styles/variables';
+@import './LoginForm.module.scss';
 
 .buttonRow {
     display: flex;

--- a/printlib-frontend/src/components/forms/RegisterForm.tsx
+++ b/printlib-frontend/src/components/forms/RegisterForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import PrintLibIntro from "../pages/3DPrintLib";
+import PrintLibIntro from "../../pages/3DPrintLib";
 import styles from './RegisterForm.module.scss';
 
 interface RegisterFormProps {


### PR DESCRIPTION
Renamed and relocated RegisterForm.tsx and RegisterForm.module.scss from components/ to components/forms/ for better organization. Updated import paths in App.tsx and within the SCSS and TSX files to reflect the new structure.